### PR TITLE
feat: add user event hooks for record/play

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ lualine_c = {
 },
 ```
 
+For event-driven statuslines such as [heirline](https://github.com/rebelot/heirline), Neocomposer 
+emits `User` autocmd events to notify the user of status changes.
+
+| User Event              | Trigger                                           | Data                    |
+| ----------------------- | ------------------------------------------------- | ----------------------- |
+| NeoComposerRecordingSet | When when starting or finishing recording a macro | { recording: boolean }  |
+| NeoComposerPlayingSet   | When when starting or finishing playing a macro   | { playing: boolean }    |
+| NeoComposerDelaySet     | When when delay is set                            | { delay: boolean }      |
+
+```lua
+{
+  provider = function(self)
+    return self.status or ""  
+  end,
+  update = {
+    "User",
+    pattern = { "NeoComposerRecordingSet", "NeoComposerPlayingSet", "NeoComposerDelaySet" },
+    callback = function(self)
+      self.status = require("neocomposer.ui").status_recording()
+    end
+  }
+}
+```
+
+
 ## 🐢 Delay Timer
 
 For complex macros over large counts, you can toggle a delay between macro playback using the `ToggleDelay` command:

--- a/lua/NeoComposer/state.lua
+++ b/lua/NeoComposer/state.lua
@@ -26,6 +26,10 @@ end
 
 function state.set_delay(delay)
   state.delay = delay
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "NeoComposerDelaySet",
+    data = { delay = delay },
+  })
 end
 
 function state.get_queued_macro()
@@ -34,6 +38,10 @@ end
 
 function state.set_playing(playing)
   state.playing = playing
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "NeoComposerPlayingSet",
+    data = { playing = playing },
+  })
 end
 
 function state.set_macros(new_macros)
@@ -42,6 +50,10 @@ end
 
 function state.set_recording(recording)
   state.recording = recording
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "NeoComposerRecordingSet",
+    data = { recording = recording },
+  })
 end
 
 function state.set_macros_loaded(loaded)


### PR DESCRIPTION
(reopened on new branch)

This PR adds hooks to NeoComposer state changes via user events. I use these for my statusline to keep components updated without calling status functions constantly.