### PR TITLE
feat!: allow customization of popup menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ lualine_c = {
 },
 ```
 
-For event-driven statuslines such as [heirline](https://github.com/rebelot/heirline), Neocomposer 
+For event-driven statuslines such as [heirline](https://github.com/rebelot/heirline), Neocomposer
 emits `User` autocmd events to notify the user of status changes.
 
 | User Event              | Trigger                                           | Data                    |
@@ -101,7 +101,7 @@ emits `User` autocmd events to notify the user of status changes.
 ```lua
 {
   provider = function(self)
-    return self.status or ""  
+    return self.status or ""
   end,
   update = {
     "User",
@@ -218,6 +218,13 @@ The available options:
 local config = {
   notify = true,
   delay_timer = 150,
+  queue_most_recent = false,
+  window = {
+    border = "rounded",
+    winhl = {
+      Normal = "ComposerNormal",
+    },
+  },
   colors = {
     bg = "#16161e",
     fg = "#ff9e64",
@@ -238,5 +245,5 @@ local config = {
 ```
 
 <h3 align="center">
-Made with ❤️  in Nebraska 
+Made with ❤️  in Nebraska
 </h3>

--- a/lua/NeoComposer.lua
+++ b/lua/NeoComposer.lua
@@ -21,20 +21,10 @@ local config = require("NeoComposer.config")
 local highlight = require("NeoComposer.highlight")
 
 function NeoComposer.setup(user_settings)
-  user_settings = user_settings or {}
+  user_settings = vim.tbl_deep_extend("force", config, user_settings or {})
 
   for k, v in pairs(user_settings) do
-    if k == "keymaps" and type(v) == "table" then
-      for key, value in pairs(v) do
-        config.keymaps[key] = value
-      end
-    elseif k == "colors" and type(v) == "table" then
-      for key, value in pairs(v) do
-        config.colors[key] = value
-      end
-    else
-      config[k] = v
-    end
+    config[k] = v
   end
 
   auto.setup()

--- a/lua/NeoComposer/config.lua
+++ b/lua/NeoComposer/config.lua
@@ -2,6 +2,14 @@ return {
   notify = true,
   delay_timer = 150,
   queue_most_recent = false,
+  window = {
+    border = "rounded",
+    winhl = {
+      Normal = "ComposerNormal",
+      FloatBorder = "ComposerBorder",
+      FloatTitle = "ComposerTitle",
+    },
+  },
   colors = {
     bg = "#16161e",
     fg = "#ff9e64",

--- a/lua/NeoComposer/highlight.lua
+++ b/lua/NeoComposer/highlight.lua
@@ -1,3 +1,5 @@
+local config = require("NeoComposer.config")
+
 local highlight = {}
 
 function highlight.setup()
@@ -5,6 +7,16 @@ function highlight.setup()
   highlight.config = { on_yank = true, timer = 500 }
   highlight.hl_yank = vim.api.nvim_create_namespace("NeoComposerYank")
   vim.api.nvim_set_hl(0, "NeoComposerYanked", { link = "Search", default = true })
+
+  vim.api.nvim_set_hl(0, "ComposerNormal", {
+    bg = config.colors.bg,
+  })
+  vim.api.nvim_set_hl(0, "ComposerBorder", {
+    link = "NormalNC"
+  })
+  vim.api.nvim_set_hl(0, "ComposerTitle", {
+    link = "NormalNC"
+  })
 end
 
 function highlight.highlight_yank(start_pos, end_pos)

--- a/lua/NeoComposer/ui.lua
+++ b/lua/NeoComposer/ui.lua
@@ -146,22 +146,29 @@ function ui.create_window()
   local width = 60
   local height = 10
   local bufnr = api.nvim_create_buf(false, false)
-  local border_chars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
 
-  local WIN_ID, win = popup.create(bufnr, {
-    minwidth = width,
-    minheight = height,
-    title = "NeoComposer",
-    borderchars = border_chars,
+  local border_chars = config.window.border or "rounded"
+  -- border is required for title
+  if border_chars == "none" then
+    border_chars = "rounded"
+  end
+
+  local WIN_ID = vim.api.nvim_open_win(bufnr, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    title = " NeoComposer ",
+    title_pos = "center",
+    border = border_chars,
     col = math.floor((vim.o.columns - width) / 2),
-    line = math.floor(((vim.o.lines - height) / 2) - 1),
+    row = math.floor(((vim.o.lines - height) / 2) - 1),
   })
 
-  local bg_color = ui.get_bg_color()
-  vim.cmd(string.format("highlight ComposerNormal guibg=%s", bg_color))
-
-  api.nvim_win_set_option(WIN_ID, "winhl", "Normal:ComposerNormal")
-  api.nvim_win_set_option(win.border.win_id, "winhl", "Normal:ComposerBorder")
+  local winhl = ""
+  for hl, val in pairs(config.window.winhl) do
+    winhl = winhl .. hl .. ":" .. val .. ","
+  end
+  api.nvim_win_set_option(WIN_ID, "winhl", winhl:sub(1, -2))
 
   return {
     bufnr = bufnr,
@@ -212,7 +219,6 @@ function ui.toggle_macro_menu()
     api.nvim_buf_set_keymap(BUFH, mode, lhs, rhs, { silent = true })
   end
 
-  api.nvim_win_set_option(WIN_ID, "number", true)
   api.nvim_buf_set_name(BUFH, "neocomposer-menu")
   api.nvim_buf_set_option(BUFH, "buftype", "acwrite")
   api.nvim_buf_set_option(BUFH, "bufhidden", "delete")


### PR DESCRIPTION
Adds customization for the window, and uses `nvim_open_win` instead of `plenary.popup` to take advantage of the builtin border.

This is a breaking change in the sense that the default border color of Plenary's popup will no longer be set if `ComposerBorder` isn't set, so by default the border is white. I removed `ComposerBorder` because it wasn't set by default, and because if users want to set the border color they can now just set `window.winhl.FloatBorder` in the config.

If this isn't desirable I can update this to use `plenary.popup`, but that would remove the ability to use the builtin borders with `"rounded"`, `"single"`, etc. and requires a second window to be opened for the border.