### PR TITLE
fix: make store compatible with lazy-loading

### DIFF
--- a/lua/NeoComposer.lua
+++ b/lua/NeoComposer.lua
@@ -27,8 +27,8 @@ function NeoComposer.setup(user_settings)
     config[k] = v
   end
 
-  auto.setup()
   store.setup()
+  auto.setup()
   highlight.setup()
   maps.setup()
 end

--- a/lua/NeoComposer/store.lua
+++ b/lua/NeoComposer/store.lua
@@ -18,15 +18,36 @@ end
 
 function store.save_macros_to_database()
   local macros = require("NeoComposer.state").get_macros()
-  store.clear_macros()
 
   store.db:with_open(function()
-    for _, macro in ipairs(macros) do
-      store.db:insert("macros", {
-        number = macro.number,
-        content = macro.content,
-      })
+    for i, macro in ipairs(macros) do
+      if
+        store.db:select("macros", {
+          where = {
+            number = i,
+          },
+        })[1]
+      then
+        store.db:update("macros", {
+          where = {
+            number = i,
+          },
+          set = {
+            content = macro.content,
+          },
+        })
+      else
+        store.db:insert("macros", {
+          number = i,
+          content = macro.content,
+        })
+      end
     end
+    store.db:delete("macros", {
+      number = {
+        [">"] = #macros + 1,
+      },
+    })
   end)
 end
 


### PR DESCRIPTION
Some fixes to the autocmds to allow for lazy-loading the plugin while still using the store.

Also makes sure macro numbers are never duplicated in the store.